### PR TITLE
[Tutorial: 4] [Feature] Add greeting from iOS (sequential)

### DIFF
--- a/KMPIntegrationDemoiOS/ContentView.swift
+++ b/KMPIntegrationDemoiOS/ContentView.swift
@@ -11,7 +11,7 @@ import shared
 struct ContentView: View {
     var body: some View {
         VStack {
-            Image(systemName: "globe")
+            Image(systemName: "hand.thumbsup")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
             Text(Greeter().greet())

--- a/kmp/shared/src/commonMain/kotlin/cz/hlinka/kmpintegrationdemo/Greeter.kt
+++ b/kmp/shared/src/commonMain/kotlin/cz/hlinka/kmpintegrationdemo/Greeter.kt
@@ -4,6 +4,6 @@ class Greeter {
     private val platform: Platform = getPlatform()
 
     fun greet(): String {
-        return "Hello KMP from Android!"
+        return "Hello KMP from Android and iOS!"
     }
 }


### PR DESCRIPTION
This PR, again, has changes to native and KMP code. After it is merged, a CI job runs a duplicates the commits that touch KMP code into the KMP repo, while stripping away the native code changes.

CR is done only here: iOS devs will review everything, Android devs will review the /kmp changes.

What the CI job runs:
git subtree push -P kmp kmp main-ios --annotate="[KMP-iOS]"
Where kmp is a remote pointing to the KMP git, and also the name of the local subtree.

This feature is done sequentially, e.g. first on Android, then integrated to iOS, then on iOS, then integrated to Android. Therefore, there will be no conflicts. Check the parallel feature PRs for that.

Continue to: https://github.com/gohlinka2/KMPIntegrationDemoAndroid/pull/3