### PR TITLE
[Tutorial: 9] [Integrate] Shine from Android

### DIFF
--- a/shared/src/commonMain/kotlin/cz/hlinka/kmpintegrationdemo/Greeter.kt
+++ b/shared/src/commonMain/kotlin/cz/hlinka/kmpintegrationdemo/Greeter.kt
@@ -4,6 +4,6 @@ class Greeter {
     private val platform: Platform = getPlatform()
 
     fun greet(): String {
-        return "Hello KMP from Android and iOS!"
+        return "Hello KMP from ✨ ANDROID ✨ and iOS!"
     }
 }


### PR DESCRIPTION
After running the pull command from `main-android`, there is a conflict:

<img width="1901" alt="Snímek obrazovky 2025-03-19 v 15 47 47" src="https://github.com/user-attachments/assets/e51965a7-b239-4600-af7d-46ca575d8ab6" />

Since we are first to integrate this, we resolve the conflicts and then the backport CI job pushes it back to main-ios, so that Android can grab the resolution we made.

Continue to: https://github.com/gohlinka2/KMPIntegrationDemoAndroid/pull/5